### PR TITLE
sounds continue to play when switching samples in desktop mode

### DIFF
--- a/samples/desktop/src/com/cookbook/samples/desktop/SwingCanvasSample.java
+++ b/samples/desktop/src/com/cookbook/samples/desktop/SwingCanvasSample.java
@@ -41,6 +41,7 @@ public class SwingCanvasSample extends JFrame implements SampleLauncher {
 		Container container = getContentPane();
 		
 		if (canvas != null) {
+			canvas.stop();
 			container.remove(canvas.getCanvas());
 		}
 		


### PR DESCRIPTION
kill the LWJGL canvas before switching to the next sample
